### PR TITLE
Update rabbitmq.rs

### DIFF
--- a/src/connections/rabbitmq.rs
+++ b/src/connections/rabbitmq.rs
@@ -2,6 +2,7 @@ use crate::models::message::Message;
 use lapin::options::*;
 use lapin::{types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties};
 use rocket::serde::json;
+use lapin::ExchangeKind;
 
 pub struct RabbitConnection {
     pub connection: Connection,

--- a/src/connections/rabbitmq.rs
+++ b/src/connections/rabbitmq.rs
@@ -1,12 +1,11 @@
 use crate::models::message::Message;
 use lapin::options::*;
-use lapin::{types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties, Queue};
+use lapin::{types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties};
 use rocket::serde::json;
 
 pub struct RabbitConnection {
     pub connection: Connection,
     pub channel: Channel,
-    pub queue: Queue,
 }
 
 impl RabbitConnection {
@@ -21,23 +20,24 @@ impl RabbitConnection {
             .create_channel()
             .await
             .expect("Could not create channel");
-        let queue = Self::create_queue(&channel).await;
-        Self {
-            connection,
-            channel,
-            queue,
-        }
-    }
-    async fn create_queue(channel: &Channel) -> Queue {
-        channel
-            .queue_declare(
+        
+        // Declare the fanout exchange
+        let exchange = channel
+            .exchange_declare(
                 "messages",
-                QueueDeclareOptions::default(),
+                ExchangeKind::Fanout,
+                ExchangeDeclareOptions::default(),
                 FieldTable::default(),
             )
             .await
-            .expect("Could not create queue")
+            .expect("Could not declare fanout exchange");
+
+        Self {
+            connection,
+            channel,
+        }
     }
+
     pub async fn reconnect(&mut self) {
         self.connection =
             Connection::connect("amqp://localhost:5672", ConnectionProperties::default())
@@ -46,16 +46,17 @@ impl RabbitConnection {
     }
 
     pub async fn publish_message(rabbit: &RabbitConnection, message: &Message) {
-        rabbit
+            rabbit
             .channel
             .basic_publish(
-                "",
-                "messages",
+                "messages", // publish to the exchange instead of the queue
+                "", // routing key is ignored for fanout exchanges
                 BasicPublishOptions::default(),
                 json::serde_json::to_string(&message).unwrap().as_bytes(),
                 BasicProperties::default(),
             )
             .await
             .expect("Failed to publish");
+    }
     }
 }

--- a/src/connections/rabbitmq.rs
+++ b/src/connections/rabbitmq.rs
@@ -58,5 +58,4 @@ impl RabbitConnection {
             .await
             .expect("Failed to publish");
     }
-    }
 }


### PR DESCRIPTION
Use fanout exchange for publishing messages to support multiple clients. The clients should connect to the exchange called messages.